### PR TITLE
Fix client-side XSS in events template

### DIFF
--- a/src/df_storyteller/web/templates/events.html
+++ b/src/df_storyteller/web/templates/events.html
@@ -42,7 +42,7 @@
                 {% endif %}
                 <div class="event-card {{ event.type }}" data-type="{{ event.type }}">
                     <div class="event-time">{{ event.type | replace('_', ' ') | title }}</div>
-                    <div class="event-text">{{ event.description | safe }}</div>
+                    <div class="event-text">{{ event.description }}</div>
                 </div>
             {% endfor %}
         {% else %}
@@ -101,10 +101,17 @@ function addEventCard(event) {
     const card = document.createElement('div');
     card.className = 'event-card ' + (event.type || '');
     card.dataset.type = event.type || 'unknown';
-    card.innerHTML = `
-        <div class="event-time">${event.season || ''} ${event.year || ''} &middot; ${event.type || ''}</div>
-        <div class="event-text">${event.description || ''}</div>
-    `;
+
+    const timeDiv = document.createElement('div');
+    timeDiv.className = 'event-time';
+    timeDiv.textContent = `${event.season || ''} ${event.year || ''} · ${event.type || ''}`;
+
+    const textDiv = document.createElement('div');
+    textDiv.className = 'event-text';
+    textDiv.textContent = event.description || '';
+
+    card.appendChild(timeDiv);
+    card.appendChild(textDiv);
 
     feed.insertBefore(card, feed.firstChild);
     allEvents.unshift(event);


### PR DESCRIPTION
## Summary
- Replace `innerHTML` with `textContent` and DOM APIs in the WebSocket event card builder to prevent XSS
- Remove `| safe` Jinja filter from server-rendered event descriptions to enable auto-escaping

## Test plan
- [x] Load the events page and verify event cards still render correctly
- [x] Trigger new events via WebSocket and confirm they appear with proper formatting
- [x] Verify that any HTML in event descriptions is escaped (shown as text, not rendered)

https://claude.ai/code/session_01CjsGY3QbZcN2AaVfzgPLCx