### PR TITLE
Fix path traversal in world switching and event WebSocket

### DIFF
--- a/src/df_storyteller/web/app.py
+++ b/src/df_storyteller/web/app.py
@@ -79,6 +79,17 @@ def _get_worlds(config: AppConfig) -> list[str]:
     )
 
 
+def _safe_watch_dir(config: AppConfig, world: str) -> Path | None:
+    """Build a watch directory path and validate it stays within the event dir."""
+    base = Path(config.paths.event_dir) if config.paths.event_dir else None
+    if not base or not world:
+        return None
+    candidate = (base / world).resolve()
+    if not candidate.is_relative_to(base.resolve()):
+        return None
+    return candidate
+
+
 def _get_active_world(config: AppConfig) -> str:
     global _active_world
     if _active_world:
@@ -1292,7 +1303,11 @@ async def api_list_worlds():
 async def api_switch_world(request: Request):
     global _active_world
     data = await request.json()
-    _active_world = data.get("world", "")
+    world = data.get("world", "")
+    config = _get_config()
+    if world and _safe_watch_dir(config, world) is None:
+        return {"ok": False, "error": "Invalid world name"}
+    _active_world = world
     _invalidate_cache()
     return {"ok": True, "active": _active_world}
 
@@ -1307,9 +1322,8 @@ async def websocket_events(websocket: WebSocket):
     _event_subscribers.append(websocket)
     try:
         config = _get_config()
-        event_dir = Path(config.paths.event_dir) if config.paths.event_dir else None
         active_world = _get_active_world(config)
-        watch_dir = event_dir / active_world if event_dir and active_world else None
+        watch_dir = _safe_watch_dir(config, active_world)
 
         # Send initial status
         if watch_dir and watch_dir.exists():


### PR DESCRIPTION
## Summary
- Add `_safe_watch_dir()` helper that resolves paths and validates they remain within the configured event directory using `Path.is_relative_to()`
- Validate world name in `POST /api/worlds/switch` to reject path traversal attempts (e.g. `../../etc`)
- Use `_safe_watch_dir()` in the `/ws/events` WebSocket handler instead of raw path concatenation

Addresses CodeQL alerts #4, #5, #6, #7, #8, #9 (uncontrolled data used in path expression).

## Test plan
- [x] Switch worlds via the UI and verify it still works
- [x] Verify WebSocket event feed connects and receives events
- [x] Confirm that a crafted world name like `../../etc` is rejected by the switch endpoint

https://claude.ai/code/session_01CjsGY3QbZcN2AaVfzgPLCx