### PR TITLE
Fix information exposure through exceptions in streaming endpoints

### DIFF
--- a/src/df_storyteller/web/app.py
+++ b/src/df_storyteller/web/app.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 from pathlib import Path
 from typing import Any, AsyncGenerator
+
+logger = logging.getLogger(__name__)
 
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
@@ -1222,8 +1225,9 @@ async def _stream_chronicle(config: AppConfig, one_time_context: str = "") -> As
         for i, word in enumerate(words):
             yield word + (" " if i < len(words) - 1 else "")
             await asyncio.sleep(0.02)
-    except Exception as e:
-        yield f"Error: {e}"
+    except Exception:
+        logger.exception("Generation failed")
+        yield "Error: generation failed. Check server logs for details."
 
 
 @app.post("/api/bio/{unit_id}")
@@ -1256,8 +1260,9 @@ async def _stream_bio(config: AppConfig, dwarf_name: str, one_time_context: str 
         for i, word in enumerate(words):
             yield word + (" " if i < len(words) - 1 else "")
             await asyncio.sleep(0.02)
-    except Exception as e:
-        yield f"Error: {e}"
+    except Exception:
+        logger.exception("Generation failed")
+        yield "Error: generation failed. Check server logs for details."
 
 
 @app.post("/api/saga/generate")
@@ -1278,8 +1283,9 @@ async def _stream_saga(config: AppConfig) -> AsyncGenerator[str, None]:
         for i, word in enumerate(words):
             yield word + (" " if i < len(words) - 1 else "")
             await asyncio.sleep(0.02)
-    except Exception as e:
-        yield f"Error: {e}"
+    except Exception:
+        logger.exception("Generation failed")
+        yield "Error: generation failed. Check server logs for details."
 
 
 @app.get("/api/worlds")


### PR DESCRIPTION
## Summary
- Replace `yield f"Error: {e}"` with a generic error message in three streaming generators (`_stream_chronicle`, `_stream_bio`, `_stream_saga`)
- Add `logger.exception()` to log the full exception server-side for debugging
- Prevents leaking internal paths, config details, or stack traces to clients

Addresses CodeQL alerts #1, #2, #3 (information exposure through an exception).

## Test plan
- [x] Trigger a chronicle/bio/saga generation and verify it streams correctly on success
- [x] Simulate a generation failure and confirm the client only sees "Error: generation failed. Check server logs for details."
- [x] Verify the full exception is logged server-side

https://claude.ai/code/session_01CjsGY3QbZcN2AaVfzgPLCx